### PR TITLE
fix: theme issue in windows

### DIFF
--- a/src/loaders/stylesLoader.ts
+++ b/src/loaders/stylesLoader.ts
@@ -9,6 +9,8 @@ import * as util from 'node:util';
 const readFile = util.promisify( fs.readFile );
 
 import type { Plugin } from 'vite';
+// eslint-disable-next-line no-duplicate-imports
+import { normalizePath } from 'vite';
 import type { CKEditor5PluginOptions } from '../index';
 import postcss, { type AcceptedPlugin } from 'postcss';
 import postcssNesting from 'postcss-nesting';
@@ -72,7 +74,7 @@ function getThemeFilePath( inputFilePath: string, theme: CKEditor5PluginOptions[
 	}
 
 	const inputFileName = inputFilePath.split(
-		path.join( packageName, 'theme', path.sep ).replace( /\\/g, '/' )
+		normalizePath( path.join( packageName, 'theme', path.sep ) )
 	)[ 1 ];
 
 	if ( !inputFileName ) {

--- a/src/loaders/stylesLoader.ts
+++ b/src/loaders/stylesLoader.ts
@@ -71,7 +71,9 @@ function getThemeFilePath( inputFilePath: string, theme: CKEditor5PluginOptions[
 		return;
 	}
 
-	const inputFileName = inputFilePath.split( path.join( packageName, 'theme', path.sep ) )[ 1 ];
+	const inputFileName = inputFilePath.split(
+		path.join( packageName, 'theme', path.sep ).replace( /\\/g, '/' )
+	)[ 1 ];
 
 	if ( !inputFileName ) {
 		return;


### PR DESCRIPTION
This is to fix https://github.com/ckeditor/vite-plugin-ckeditor5/issues/2
There seems to be inconsistency in path.join in unix and windows, which causes the plugin to fail fetching the theme css.
Updated https://github.com/ckeditor/vite-plugin-ckeditor5/blob/master/src/loaders/stylesLoader.ts to use normalizePath with path.join to make it consistent in unix and windows systems.