### PR TITLE
Fix: Handle source maps properly. Closes: #8.

### DIFF
--- a/playground/vanilla-sample/vite.config.js
+++ b/playground/vanilla-sample/vite.config.js
@@ -12,7 +12,8 @@ import ckeditor5 from '../../dist/index.mjs';
 export default defineConfig( {
 	root: './src',
 	build: {
-		outDir: '../dist'
+		outDir: '../dist',
+		sourcemap: true
 	},
 	esbuild: {
 		sourcemap: true

--- a/playground/vue-sample/vite.config.js
+++ b/playground/vue-sample/vite.config.js
@@ -15,5 +15,8 @@ export default defineConfig( {
 	plugins: [
 		vue(),
 		ckeditor5( { theme: require.resolve( '@ckeditor/ckeditor5-theme-lark' ) } )
-	]
+	],
+	build: {
+		sourcemap: true
+	}
 } );

--- a/src/loaders/stylesLoader.ts
+++ b/src/loaders/stylesLoader.ts
@@ -34,7 +34,7 @@ const stylesLoader = ( theme: CKEditor5PluginOptions['theme'] ): Plugin => {
 			}
 
 			const themeStyles = await loadThemeStyles( id, theme );
-			const stylesToLoad = code + themeStyles;
+			const stylesToLoad = code + themeStyles.code;
 
 			return loadPostcssFile( stylesToLoad, id );
 		}
@@ -48,18 +48,20 @@ async function loadThemeStyles( id: string, theme: string ) {
 
 	if ( themeFilePath && fs.existsSync( themeFilePath ) ) {
 		const css = await readFile( themeFilePath );
-		const result = await postcss( postcssOptions ).process( css, { from: themeFilePath } );
-		return result.css.toString();
+		const result = await postcss( postcssOptions ).process( css, { from: themeFilePath, map: { absolute: true, inline: false } } );
+
+		return { code: result.css.toString(), map: result.map.toString() };
 	}
 
-	return '';
+	return { code: '' };
 }
 
 async function loadPostcssFile( code: string, id: string ) {
-	const result = await postcss( postcssOptions ).process( code, { from: id } );
+	const result = await postcss( postcssOptions ).process( code, { from: id, map: { absolute: true, inline: false } } );
 
 	return {
-		code: result.css.toString()
+		code: result.css.toString(),
+		map: result.map.toString()
 	};
 }
 


### PR DESCRIPTION
Commit message:
```
Handle CSS source maps properly

Fix: Using sourcemap option in Vite no longer results in warnings from vite-ckeditor5-styles-loader. Closes: #8.
```

Closes: #8. 