### PR TITLE
Fix: Include external plugins names when checking icon paths. Closes: #10.

### DIFF
--- a/src/loaders/iconsLoader.ts
+++ b/src/loaders/iconsLoader.ts
@@ -7,7 +7,7 @@ import type { Plugin } from 'vite';
 
 import * as fs from 'node:fs';
 
-const isCKEditor5Icon = ( id: string ) => id.endsWith( '.svg' ) && id.includes( 'ckeditor5-' );
+const isCKEditor5Icon = ( id: string ) => id.endsWith( '.svg' ) && ( id.includes( 'ckeditor5-' ) || id.includes( '-ckeditor5' ) );
 
 const iconsLoader = (): Plugin => {
 	return {


### PR DESCRIPTION
Commit message:
```
Include external plugins names when checking icon paths

Fix: Using external plugins with different name conventions than official CKEditor 5 plugins no longer results in editor crash. Closes: #10.

```

Closes: #10.